### PR TITLE
feat: add arm architecture support

### DIFF
--- a/src/client/LocalBlockReader.cpp
+++ b/src/client/LocalBlockReader.cpp
@@ -84,11 +84,15 @@ LocalBlockReader::LocalBlockReader(const shared_ptr<ReadShortCircuitInfo>& info,
 
         case ChecksumTypeProto::CHECKSUM_CRC32:
         case ChecksumTypeProto::CHECKSUM_CRC32C:
+            #if !defined(__X86__)
+             checksum = shared_ptr<Checksum>(new SWCrc32c());
+        #else
             if (HWCrc32c::available()) {
                 checksum = shared_ptr<Checksum>(new HWCrc32c());
             } else {
                 checksum = shared_ptr<Checksum>(new SWCrc32c());
             }
+        #endif
 
             chunkSize = ReadBigEndian32FromArray(
                             &pMetaBuffer[BMVERSION_SIZE + CHECKSUM_TYPE_SIZE]);

--- a/src/client/OutputStreamImpl.cpp
+++ b/src/client/OutputStreamImpl.cpp
@@ -29,7 +29,9 @@
 #include "Exception.h"
 #include "ExceptionInternal.h"
 #include "FileSystemInter.h"
+#if defined(__X86__)
 #include "HWCrc32c.h"
+#endif
 #include "LeaseRenewer.h"
 #include "Logger.h"
 #include "OutputStream.h"
@@ -49,11 +51,15 @@ OutputStreamImpl::OutputStreamImpl() :
         0), chunksPerPacket(0), closeTimeout(0), heartBeatInterval(0), packetSize(0), position(
             0), replication(0), blockSize(0), bytesWritten(0), cursor(0), lastFlushed(
                 0), nextSeqNo(0), packets(0), cryptoCodec(NULL), kcp(NULL) {
+    #if defined(__X86__)
     if (HWCrc32c::available()) {
         checksum = shared_ptr < Checksum > (new HWCrc32c());
     } else {
         checksum = shared_ptr < Checksum > (new SWCrc32c());
     }
+    #else
+    checksum = shared_ptr < Checksum > (new SWCrc32c());
+    #endif
 
     checksumSize = sizeof(int32_t);
     lastSend = steady_clock::now();

--- a/src/client/RemoteBlockReader.cpp
+++ b/src/client/RemoteBlockReader.cpp
@@ -29,7 +29,9 @@
 #include "Exception.h"
 #include "ExceptionInternal.h"
 #include "Metrics.h"
+#if defined(__X86__)
 #include "HWCrc32c.h"
+#endif
 #include "RemoteBlockReader.h"
 #include "SWCrc32c.h"
 #include "WriteBuffer.h"
@@ -213,11 +215,15 @@ void RemoteBlockReader::checkResponse() {
 
     case ChecksumTypeProto::CHECKSUM_CRC32:
     case ChecksumTypeProto::CHECKSUM_CRC32C:
+	#if defined(__X86__)
         if (HWCrc32c::available()) {
             checksum = shared_ptr<Checksum>(new HWCrc32c());
         } else {
             checksum = shared_ptr<Checksum>(new SWCrc32c());
         }
+        #else
+            checksum = shared_ptr < Checksum > (new SWCrc32c());
+        #endif
 
         checksumSize = sizeof(int32_t);
         break;

--- a/src/client/async_preader/AsyncPReaderCallback.cpp
+++ b/src/client/async_preader/AsyncPReaderCallback.cpp
@@ -428,6 +428,7 @@ namespace Internal
 
                     case ChecksumTypeProto::CHECKSUM_CRC32:
                     case ChecksumTypeProto::CHECKSUM_CRC32C:
+                        #if defined(__X86__)
                         if (HWCrc32c::available())
                         {
                             checksum = shared_ptr<Checksum>(new HWCrc32c());
@@ -436,6 +437,9 @@ namespace Internal
                         {
                             checksum = shared_ptr<Checksum>(new SWCrc32c());
                         }
+                        #else
+                             checksum = shared_ptr<Checksum>(new SWCrc32c());
+                        #endif
 
                         checksumSize = sizeof(int32_t);
                         break;

--- a/src/common/HWCrc32c.cpp
+++ b/src/common/HWCrc32c.cpp
@@ -161,4 +161,14 @@ void HWCrc32c::updateInt64(const char * b, int len) {
 }
 }
 
+#else
+namespace Hdfs {
+namespace Internal {
+bool HWCrc32c::available() {
+   return false;
+}
+}
+}
+
+
 #endif /* _HDFS_LIBHDFS3_COMMON_HWCHECKSUM_H_ */


### PR DESCRIPTION
Modify the corresponding foundationdb package to support the use of the corresponding ARM version of the package in the aarch64  environment.
Submit association with byconity [feat: add aarch64 support #1291]